### PR TITLE
Fixing fatal compile error when attempting to build with JDK 16

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
         <!-- The destination file for the code coverage report has to be set to the same value
             in the parent pom and in each module pom. Then JaCoCo will add up information in
             the same report, so that, it will give the cross-module code coverage. -->
-        <lombok.version>1.18.0</lombok.version>
+        <lombok.version>1.18.22</lombok.version>
         <junit.version>4.12</junit.version>
         <org.mockito.version>1.9.5</org.mockito.version>
 	<sonar.projectKey>Mastercard_xmlsignverify-core-java</sonar.projectKey>


### PR DESCRIPTION
When attempting the build the project with AdoptOpenJDK 16.0.1.9, we get the following error:

```
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 2.376 s
[INFO] Finished at: 2021-10-08T14:19:30+01:00
[INFO] Final Memory: 17M/74M
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.8.0:compile (default-compile) on project xmlsignverify-core-java: Fatal error compiling: java.lang.ExceptionInInitializerError: Unable to make field private com.sun.tools.javac.processing.JavacProcessingEnvironment$DiscoveredProcessors com.sun.tools.javac.processing.JavacProcessingEnvironment.discoveredProcs accessible: module jdk.compiler does not "opens com.sun.tools.javac.processing" to unnamed module @2753316c -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoExecutionException
```

It appears that this is caused by the version of lombok used. Updating the lombok version fixes the issue, and allows the project to be built.