### PR TITLE
Updating xmlsec dependency for CVE-2021-40690

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <properties>
         <maven-compiler-plugin.version>3.8.0</maven-compiler-plugin.version>
         <java.version>11</java.version>
-        <org.apache.santuario.xmlsec.version>2.1.4</org.apache.santuario.xmlsec.version>
+        <org.apache.santuario.xmlsec.version>2.2.3</org.apache.santuario.xmlsec.version>
         <net.sf.saxon.version>10.1</net.sf.saxon.version>
         <jacoco-maven-plugin.version>0.8.6</jacoco-maven-plugin.version>
         <plugin.site.version>3.3</plugin.site.version>

--- a/src/test/java/com/mastercard/ap/security/bah/utility/XmlSignUtilTest.java
+++ b/src/test/java/com/mastercard/ap/security/bah/utility/XmlSignUtilTest.java
@@ -31,11 +31,8 @@ import org.junit.Test;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
-import org.xml.sax.SAXException;
 
-import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.xpath.XPathExpressionException;
-import javax.xml.xpath.XPathFactoryConfigurationException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.security.KeyPair;
@@ -117,9 +114,9 @@ public class XmlSignUtilTest {
         XMLUtils.outputDOM(signedDocument, System.out);
     }
 
-    private Document getSignedDocument() throws ParserConfigurationException, SAXException, IOException, XMLSecurityException, XPathExpressionException, XPathFactoryConfigurationException {
+    private Document getSignedDocument() throws XMLSecurityException, XPathExpressionException {
         InputStream sourceDocument = this.getClass().getResourceAsStream("/source-unsigned.xml");
-        Document unSignedDocument = XMLUtils.read(sourceDocument);
+        Document unSignedDocument = XMLUtils.read(sourceDocument, true);
 
         SignatureKeyInfo signatureKeyInfo = SignatureKeyInfo.builder()
                 .privateKey(privateKey)


### PR DESCRIPTION
Updating the xmlsec dependency to 2.2.3 to resolve CVE-2021-40690.

The `XMLUtils.read(inputstream)` method is no longer available, but this was just a convenience method for `XMLUtils.read(inputstream, true)`, and so I have replaced it with that.