### PR TITLE
docs: fix maven dependency snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,8 @@ Refer to [detailed message verification flow](docs/MessageVerificationFlow.md)
 ```xml
 <dependency>
     <groupId>com.mastercard.ap.security</groupId>
-    <artifactId>ap-bah-crypto-utility</artifactId>
-    <version>${bah-crypto-utility-version}</version>
+    <artifactId>xmlsignverify-core-java</artifactId>
+    <version>1.0.0</version>
 </dependency>
 ```
 


### PR DESCRIPTION
I couldn't find this jar published on maven, but the snippet to import it didn't match the pom.xml anyway. 

Issue: https://github.com/Mastercard/xmlsignverify-core-java/issues/6 